### PR TITLE
fix dimension pivot

### DIFF
--- a/databaker/bake.py
+++ b/databaker/bake.py
@@ -83,7 +83,7 @@ def rewrite_headers(row,dims):
             which_cell_in_spread = (i - len(template.start.split(','))) % len(template.value_spread)
             which_dim = (i - len(template.start.split(','))) / len(template.value_spread)
             which_dim = int(which_dim)
-            if value_spread[which_cell_in_spread] == 'value':
+            if template.value_spread[which_cell_in_spread] == 'value':
                 row[i] = dims[which_dim]
     return row
 


### PR DESCRIPTION
same change I proposed before. Variable got buried when we were tidying up after the custom structures code.

Darren's been showing how you can move dimension names to be column header at CSVconf - it'll fail using this repo until this is implemented, fair warning.

Cheers
Mike
