### PR TITLE
Update version numbers to 1.2.0

### DIFF
--- a/databaker/bake.py
+++ b/databaker/bake.py
@@ -54,7 +54,7 @@ except ImportError:
     from .structure_csv_default import *
 
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 
 crash_msg = []
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ Transform Excel spreadsheets
 
 conf = dict(
     name='databaker',
-    version='1.1.0',
+    version='1.2.0',
     description="DataBaker, part of QuickCode for ONS",
     long_description=long_desc,
     classifiers=[


### PR DESCRIPTION
There was already a 1.1.1 release on PyPI, but the version numbers
hadn't been updated in the source.

Instead, bump the version to 1.2.0 to avoid ambiguity.