### PR TITLE
Add explicit file encoding when opening files

### DIFF
--- a/databaker/jupybakecsv.py
+++ b/databaker/jupybakecsv.py
@@ -27,7 +27,7 @@ def writetechnicalCSV(outputfile, conversionsegments):
         
     if outputfile is not None:
         print("writing %d conversion segments into %s" % (len(conversionsegments), os.path.abspath(outputfile)))
-        filehandle = open(outputfile, "w", newline='\n')
+        filehandle = open(outputfile, "w", newline='\n', encoding='utf-8')
     else:
         filehandle = io.StringIO()
     csv_writer = csv.writer(filehandle)
@@ -99,7 +99,7 @@ def readtechnicalCSV(wdafile, bverbose):
         if len(wdafile) > 200 and '\n' in wdafile:
             filehandle = io.StringIO(wdafile)
         else:
-            filehandle = open(wdafile, "r")
+            filehandle = open(wdafile, "r", encoding='utf-8')
     else:
         assert isinstance(wdafile, io.StringIO)
         filehandle = wdafile

--- a/databaker/jupybakeutils.py
+++ b/databaker/jupybakeutils.py
@@ -385,7 +385,7 @@ def LwritetechnicalCSV(outputfile, conversionsegments):
         
     if outputfile is not None:
         print("writing %d conversion segments into %s" % (len(conversionsegments), os.path.abspath(outputfile)))
-        filehandle = open(outputfile, "w", newline='\n')
+        filehandle = open(outputfile, "w", newline='\n', encoding='utf-8')
     else:
         filehandle = io.StringIO()
     csv_writer = csv.writer(filehandle)

--- a/databaker/utils.py
+++ b/databaker/utils.py
@@ -182,7 +182,7 @@ class TechnicalCSV(object):
         self.no_lookup_error = no_lookup_error
         self.filename = filename
         if filename is not None:
-            self.filehandle = open(filename, mode, newline='\n')
+            self.filehandle = open(filename, mode, newline='\n', encoding='utf-8')
         else:
             self.filehandle = io.StringIO()
         self.csv_writer = UnicodeWriter(self.filehandle)


### PR DESCRIPTION
When no encoding is specified, Python uses
locale.getpreferredencoding() to set one, and this is platform
dependent.

Linux distros often default to UTF-8 locale, Windows uses CP1252, which
caused issues for Mike.